### PR TITLE
Add EmailJS-powered contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Prueba
-pruebas
+
+Sitio de ejemplo con formulario de contacto.
+
+## Configuración de EmailJS
+
+El formulario está conectado con [EmailJS](https://www.emailjs.com/).
+Para que funcione, reemplaza los valores de ejemplo en
+`assets/js/scripts.js`:
+
+1. `PUBLIC_KEY` – tu **Public Key** de EmailJS.
+2. `SERVICE_ID` – el ID del servicio creado en EmailJS.
+3. `TEMPLATE_ID` – el ID de la plantilla usada para el mensaje.
+
+```js
+emailjs.init('PUBLIC_KEY');
+const serviceID = 'SERVICE_ID';
+const templateID = 'TEMPLATE_ID';
+```
+
+## ¿Usas Netlify?
+
+Si despliegas el sitio en Netlify puedes eliminar EmailJS y usar
+Netlify Forms:
+
+1. Quita los scripts de EmailJS en `index.html`.
+2. Añade `data-netlify="true"` y un campo oculto `form-name` al `<form>`.
+
+Consulta la [documentación de Netlify Forms](https://docs.netlify.com/forms/setup/).

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -14,13 +14,47 @@
     });
   }
 
-  // Demo de envío de formulario (reemplazar por integración real)
+  // Inicializar EmailJS (reemplaza "PUBLIC_KEY" con tu clave pública)
+  if (window.emailjs) {
+    emailjs.init('PUBLIC_KEY');
+  }
+
+  const serviceID = 'SERVICE_ID';
+  const templateID = 'TEMPLATE_ID';
+
+  // Envío del formulario con validación básica
   const form = document.querySelector('.contact-form');
   if (form) {
     form.addEventListener('submit', (e) => {
       e.preventDefault();
-      alert('¡Gracias! Te contactaremos muy pronto.');
-      form.reset();
+
+      const nombre = form.from_name.value.trim();
+      const correo = form.reply_to.value.trim();
+      const mensaje = form.message.value.trim();
+
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+      if (!nombre || !correo || !mensaje) {
+        alert('Por favor completa todos los campos.');
+        return;
+      }
+
+      if (!emailRegex.test(correo)) {
+        alert('Ingresa un correo válido.');
+        return;
+      }
+
+      emailjs.send(serviceID, templateID, {
+        from_name: nombre,
+        reply_to: correo,
+        message: mensaje
+      }).then(() => {
+        alert('¡Gracias! Te contactaremos muy pronto.');
+        form.reset();
+      }).catch((err) => {
+        console.error('Error al enviar', err);
+        alert('Ocurrió un problema al enviar el mensaje.');
+      });
     });
   }
 })();

--- a/index.html
+++ b/index.html
@@ -78,6 +78,43 @@
             border-radius: 10px;
         }
 
+        .contacto {
+            background-color: #f9f9f9;
+            padding: 2rem;
+            border-radius: 10px;
+        }
+
+        .contact-form {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            max-width: 500px;
+            margin: auto;
+        }
+
+        .contact-form label {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .contact-form input,
+        .contact-form textarea {
+            padding: 0.5rem;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+
+        .contact-form button {
+            align-self: flex-start;
+            background-color: var(--dorado);
+            color: var(--azul);
+            border: none;
+            padding: 0.75rem 1.5rem;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+
         footer {
             background-color: var(--azul);
             color: var(--blanco);
@@ -95,7 +132,7 @@
             <a href="#">Inicio</a>
             <a href="#">Servicios</a>
             <a href="#">Testimonios</a>
-            <a href="#">Contacto</a>
+            <a href="#contacto">Contacto</a>
         </nav>
     </header>
 
@@ -132,9 +169,29 @@
         <p>"Muy profesionales, entrega rápida y de calidad." - Cliente satisfecho</p>
     </section>
 
+    <section id="contacto" class="section contacto">
+        <h2>Contacto</h2>
+        <form class="contact-form">
+            <label>
+                Nombre
+                <input type="text" name="from_name" required>
+            </label>
+            <label>
+                Email
+                <input type="email" name="reply_to" required>
+            </label>
+            <label>
+                Mensaje
+                <textarea name="message" rows="5" required></textarea>
+            </label>
+            <button type="submit">Enviar</button>
+        </form>
+    </section>
+
     <footer>
         <p>&copy; 2025 Maldrec - Todos los derechos reservados</p>
     </footer>
-
+    <script src="https://cdn.jsdelivr.net/npm/emailjs-com@3/dist/email.min.js"></script>
+    <script src="assets/js/scripts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate EmailJS to send contact form emails
- add client-side validation and contact section
- document how to configure keys or switch to Netlify Forms

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b98626f6c8325b6ed50e6df6ed725