### PR TITLE
Add GitHub Pages workflow and demo link

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Minify files
+        run: |
+          npx html-minifier-terser --input-dir . --output-dir dist --collapse-whitespace --remove-comments --minify-css true --minify-js true
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Sitio de ejemplo con formulario de contacto.
 
+## Demo
+
+El sitio está publicado en GitHub Pages: https://<tu-usuario>.github.io/Prueba/
+
 ## Configuración de EmailJS
 
 El formulario está conectado con [EmailJS](https://www.emailjs.com/).


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow that minifies assets and deploys to Pages
- document Pages demo URL in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba6ad1e108325a2cc813a3d57084a